### PR TITLE
fix/scrolling header upwards

### DIFF
--- a/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
@@ -102,6 +102,8 @@ export class FixedSizeTableVirtualScrollStrategy implements VirtualScrollStrateg
     const buffer = Math.ceil(amount * this.bufferMultiplier);
     const end = start + amount + buffer;
 
+    console.log(`Initial offset and range ${JSON.stringify({renderedOffset, start, end})}`);
+
 
     const lowerBuffer = Math.min(buffer, start);
     const bufferOffset = renderedOffset + lowerBuffer * this.rowHeight;
@@ -113,6 +115,7 @@ export class FixedSizeTableVirtualScrollStrategy implements VirtualScrollStrateg
 
     // Only bother updating the displayed information if we've scrolled more than a row
     const rowSensitivity = 1.0;
+    console.log(`Rows scrolled: ${rowsScrolled}`);
     if (Math.abs(rowsScrolled) < rowSensitivity) {
       this.viewport.setRenderedContentOffset(renderedOffset);
       this.viewport.setRenderedRange({start, end});
@@ -120,7 +123,7 @@ export class FixedSizeTableVirtualScrollStrategy implements VirtualScrollStrateg
     }
 
     const rowsToMove = Math.sign(rowsScrolled) * Math.floor(Math.abs(rowsScrolled));
-    const adjustedRenderedOffset = renderedOffset + rowsToMove * this.rowHeight;
+    const adjustedRenderedOffset = Math.max(0, renderedOffset + rowsToMove * this.rowHeight);
     this.viewport.setRenderedContentOffset(adjustedRenderedOffset);
 
     const adjustedStart = Math.max(0, start + rowsToMove);
@@ -129,5 +132,7 @@ export class FixedSizeTableVirtualScrollStrategy implements VirtualScrollStrateg
 
     this.indexChange.next(adjustedStart - lowerBuffer);
     this.stickyChange.next(adjustedRenderedOffset);
+    console.log(`Setting offset and range ${JSON.stringify({adjustedRenderedOffset, adjustedStart, adjustedEnd})}`)
+
   }
 }

--- a/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
@@ -135,7 +135,7 @@ export class FixedSizeTableVirtualScrollStrategy implements VirtualScrollStrateg
     this.viewport.setRenderedContentOffset(adjustedRenderedOffset);
 
     const adjustedStart = Math.max(0, start + rowsToMove);
-    const adjustedEnd = adjustedStart + itemsDisplayed + bufferItems;
+    const adjustedEnd = adjustedStart + itemsDisplayed + 2 * bufferItems;
     this.viewport.setRenderedRange({start: adjustedStart, end: adjustedEnd});
 
     this.stickyChange.next(adjustedRenderedOffset);

--- a/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
@@ -61,7 +61,6 @@ export class FixedSizeTableVirtualScrollStrategy implements VirtualScrollStrateg
   }
 
   public onContentRendered(): void {
-    // no-op
   }
 
   public onRenderedOffsetChanged(): void {
@@ -96,19 +95,39 @@ export class FixedSizeTableVirtualScrollStrategy implements VirtualScrollStrateg
     if (!this.viewport || !this.rowHeight) {
       return;
     }
-    const scrollOffset = this.viewport.measureScrollOffset();
-    const amount = Math.ceil(this.viewport.getViewportSize() / this.rowHeight);
-    const offset = Math.max(scrollOffset - this.headerHeight, 0);
-    const buffer = Math.ceil(amount * this.bufferMultiplier);
 
-    const skip = Math.round(offset / this.rowHeight);
-    const index = Math.max(0, skip);
-    const start = Math.max(0, index - buffer);
-    const end = Math.min(this.dataLength, index + amount + buffer);
-    const renderedOffset = start * this.rowHeight;
-    this.viewport.setRenderedContentOffset(renderedOffset);
-    this.viewport.setRenderedRange({start, end});
-    this.indexChange.next(index);
-    this.stickyChange.next(renderedOffset);
+    const renderedOffset = this.viewport.getOffsetToRenderedContentStart();
+    const start = renderedOffset / this.rowHeight;
+    const amount = Math.ceil(this.viewport.getViewportSize() / this.rowHeight);
+    const buffer = Math.ceil(amount * this.bufferMultiplier);
+    const end = start + amount + buffer;
+
+
+    const lowerBuffer = Math.min(buffer, start);
+    const bufferOffset = renderedOffset + lowerBuffer * this.rowHeight;
+    const scrollOffset = this.viewport.measureScrollOffset();
+
+    // How far the scroll offset is from the actual start of displayed information
+    const relativeScrollOffset = scrollOffset - bufferOffset;
+    const rowsScrolled = relativeScrollOffset / this.rowHeight;
+
+    // Only bother updating the displayed information if we've scrolled more than a row
+    const rowSensitivity = 1.0;
+    if (Math.abs(rowsScrolled) < rowSensitivity) {
+      this.viewport.setRenderedContentOffset(renderedOffset);
+      this.viewport.setRenderedRange({start, end});
+      return;
+    }
+
+    const rowsToMove = Math.sign(rowsScrolled) * Math.floor(Math.abs(rowsScrolled));
+    const adjustedRenderedOffset = renderedOffset + rowsToMove * this.rowHeight;
+    this.viewport.setRenderedContentOffset(adjustedRenderedOffset);
+
+    const adjustedStart = Math.max(0, start + rowsToMove);
+    const adjustedEnd = adjustedStart + amount + buffer;
+    this.viewport.setRenderedRange({start: adjustedStart, end: adjustedEnd});
+
+    this.indexChange.next(adjustedStart - lowerBuffer);
+    this.stickyChange.next(adjustedRenderedOffset);
   }
 }

--- a/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
@@ -118,6 +118,7 @@ export class FixedSizeTableVirtualScrollStrategy implements VirtualScrollStrateg
     if (Math.abs(rowsScrolled) < rowSensitivity) {
       this.viewport.setRenderedContentOffset(renderedOffset);
       this.viewport.setRenderedRange({start, end});
+      this.stickyChange.next(renderedOffset);
       return;
     }
 
@@ -127,6 +128,7 @@ export class FixedSizeTableVirtualScrollStrategy implements VirtualScrollStrateg
     if (renderedOffset === 0 && rowsScrolled < 0) {
       this.viewport.setRenderedContentOffset(renderedOffset);
       this.viewport.setRenderedRange({start, end});
+      this.stickyChange.next(0);
       return;
     }
 

--- a/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
@@ -71,7 +71,7 @@ export class FixedSizeTableVirtualScrollStrategy implements VirtualScrollStrateg
     if (!this.viewport || !this.rowHeight) {
       return;
     }
-    this.viewport.scrollToOffset((index - 1 ) * this.rowHeight + this.headerHeight, behavior);
+    this.viewport.scrollToOffset(index * this.rowHeight, behavior);
   }
 
   public setConfig(configs: TSVStrategyConfigs) {

--- a/projects/ng-table-virtual-scroll/src/lib/table-item-size.directive.spec.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/table-item-size.directive.spec.ts
@@ -159,14 +159,14 @@ describe('TableItemSizeDirective', () => {
     const tbody = fixture.nativeElement.querySelector('tbody');
 
     expect(tbody.children.length)
-      .toBe(6, 'should render 6 10px row to fill 40px*(1 + 0.5) space');
+      .toBe(8, 'should render 8 10px row to fill 40px + 40px * 0.5 (buffer before) + 40px * 0.5 (buffer after) space');
   }));
 
   it('get the rendered range', fakeAsync(() => {
     finishInit(fixture);
 
     expect(viewport.getRenderedRange())
-      .toEqual({start: 0, end: 6}, 'should render the first 6 10px items to fill 40px*(1 + 0.5) space');
+      .toEqual({start: 0, end: 8}, 'should render 8 10px row to fill 40px + 40px * 0.5 (buffer before) + 40px * 0.5 (buffer after) space');
   }));
 
   it('should set the correct rendered range on scroll', fakeAsync(() => {
@@ -180,7 +180,7 @@ describe('TableItemSizeDirective', () => {
     flush();
 
     expect(viewport.getRenderedRange())
-      .toEqual({start: 6, end: 14}, 'current index should be 8, buffer = 2');
+      .toEqual({start: 8, end: 16}, 'scrolled ten items down, so items 10-14 should be visible, with items 8-16 rendered in the buffer');
   }));
 
   it('should subscribe and rerender after dataSource is changed', fakeAsync(() => {

--- a/projects/ng-table-virtual-scroll/src/lib/table-item-size.directive.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/table-item-size.directive.ts
@@ -1,6 +1,7 @@
+import { VIRTUAL_SCROLL_STRATEGY } from '@angular/cdk/scrolling';
+import { CdkHeaderRowDef } from '@angular/cdk/table';
 import {
-  AfterContentInit,
-  ContentChild,
+  AfterContentInit, ContentChild,
   Directive,
   forwardRef,
   Input,
@@ -8,13 +9,11 @@ import {
   OnChanges,
   OnDestroy
 } from '@angular/core';
-import { VIRTUAL_SCROLL_STRATEGY } from '@angular/cdk/scrolling';
-import { delayWhen, distinctUntilChanged, filter, map, switchMap, takeUntil, tap } from 'rxjs/operators';
-import { TableVirtualScrollDataSource } from './table-data-source';
 import { MatTable } from '@angular/material/table';
+import { Subject } from 'rxjs';
+import { distinctUntilChanged, filter, map, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { FixedSizeTableVirtualScrollStrategy } from './fixed-size-table-virtual-scroll-strategy';
-import { CdkHeaderRowDef } from '@angular/cdk/table';
-import { of, Subject, timer } from 'rxjs';
+import { TableVirtualScrollDataSource } from './table-data-source';
 
 export function _tableVirtualScrollDirectiveStrategyFactory(tableDir: TableItemSizeDirective) {
   return tableDir.scrollStrategy;
@@ -98,7 +97,6 @@ export class TableItemSizeDirective implements OnChanges, AfterContentInit, OnDe
     this.scrollStrategy.stickyChange
       .pipe(
         filter(() => this.isStickyEnabled()),
-        delayWhen(() => !this.stickyPositions ? timer(0) : of()),
         tap(() => {
           if (!this.stickyPositions) {
             this.initStickyPositions();
@@ -126,9 +124,9 @@ export class TableItemSizeDirective implements OnChanges, AfterContentInit, OnDe
               .renderedRangeStream
               .pipe(
                 map(({
-                       start,
-                       end
-                     }) => typeof start !== 'number' || typeof end !== 'number' ? data : data.slice(start, end))
+                  start,
+                  end
+                }) => typeof start !== 'number' || typeof end !== 'number' ? data : data.slice(start, end))
               )
           )
         )


### PR DESCRIPTION
- ScrollingFix: Changing scroll detection algorithm to use relative scroll distances
- ScrollingFix: Preventing negative offset values
- ScrollingFix: Changing start/end to be the rendered start and end
- StickyFix: Last test fixes
- fix: fixes behaviour where upwards scrolling of first rendered data did cut off half of the header, if header and rows are not equal in height
